### PR TITLE
working: sorted required depedency listing

### DIFF
--- a/Choam.toml
+++ b/Choam.toml
@@ -6,12 +6,10 @@ repo = "https://github.com/cowboycodr/choam"
 keywords = [ "package", "manager",]
 
 [modules]
-choam = "*"
-toml = "*"
 fire = "*"
-findimports = "*"
-pathlib = "*"
-shutil = "*"
+toml = "*"
+choam = "*"
 typing = "*"
-twine = "*"
-wheel = "*"
+shutil = "*"
+pathlib = "*"
+findimports = "*"

--- a/choam/__main__.py
+++ b/choam/__main__.py
@@ -240,7 +240,7 @@ class Choam:
 
     depedencies = find_dependencies()
     new_config = Choam._get_config()
-    new_config['modules'] = {key: "*" for key in list(depedencies)}
+    new_config['modules'] = {dep: "*" for dep in sorted(list(depedencies), key=len)}
 
     Choam._set_config(toml.dumps(new_config))
   


### PR DESCRIPTION
Required dependencies are not sorted by length in `Choam.toml`