### PR TITLE
Remove the requirement of having a modules-ignore in Choam.toml

### DIFF
--- a/choam/find_dependencies.py
+++ b/choam/find_dependencies.py
@@ -256,8 +256,11 @@ def find_dependencies():
         config = toml.loads(file.read())
 
         project_name = config["package"]["name"]
-        ignored_deps = config["modules-ignore"]
-
+        try:
+            ignored_deps = config["modules-ignore"]
+        except KeyError:
+            ignored_deps = []
+        
     found_depedencies = _find_dependencies(project_path, project_name)
     dependencies = []
 


### PR DESCRIPTION
If modules-ignore is not there in Choam.toml, the program now ignores it.